### PR TITLE
Add note about type hinting

### DIFF
--- a/CI/linters.md
+++ b/CI/linters.md
@@ -10,3 +10,7 @@ In our continuous integration (CI) pipeline, we utilize several linters to maint
 - [flynt](https://pypi.org/project/flynt/) - string formatting converter that converts Python code from old `"%-formatted"` and `.format(...)` strings into Python 3.6+'s `"f-strings"`.
 
 The use of linters is critical for several reasons. First, linters help ensure that our codebase follows coding standards, conventions, and best practices, improving readability and maintainability. By detecting potential problems such as syntax errors, style violations, unused variables, and type inconsistencies early on, linters help prevent bugs and improve codebase quality. In addition, linters promote consistency within the codebase, making it easier for developers to collaborate and understand each other's code.
+
+## Type Hinting
+
+Use of [type hinting](https://docs.python.org/3/library/typing.html) is strongly encouraged. For existing repos, running mypy as a required check during CI is optional. All new repos should enable mypy as a required check during CI, however. In general, all PRs should include type hints, though there may be cases where type hinting is impractical due to, for example, third party libraries that lack types or type stubs. In these cases, consider whether the work required to create and maintain type stubs would be beneficial to the project.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This proposes making type hinting and mypy a requirement for all new python projects. Existing projects should be handled on a case by case basis to determine if enabling mypy during CI would be worthwhile.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
