### PR TITLE
Remove collections no longer maintained by team

### DIFF
--- a/collections-overview.md
+++ b/collections-overview.md
@@ -10,17 +10,14 @@ See the [collections release tracker](https://cloud-releases.jillr.dev/) for an 
 | [amazon.cloud](https://github.com/ansible-collections/amazon.cloud) | Community | Generated modules for AWS using the Cloud Control API |
 | [cloud.aws_ops](https://github.com/redhat-cop/cloud.aws_ops) | Validated content | Roles and playbooks for managing AWS resources |
 | [cloud.aws_troubleshooting](https://github.com/redhat-cop/cloud.aws_troubleshooting) | Validated content | Roles to help troubleshoot AWS resources |
-| [cloud.azure_ops](https://github.com/redhat-cop/cloud.azure_ops) | Validated content | Roles and playbooks for managing Azure resources |
 | [cloud.common](https://github.com/ansible-collections/cloud.common) | Supported | Helper collection for cloud |
 | [cloud.gcp_ops](https://github.com/redhat-cop/cloud.gcp_ops) | Validated content | Roles and playbooks for managing GCP resources |
 | [cloud.terraform](https://github.com/ansible-collections/cloud.terraform) | Supported | Automate the management and provisioning of infrastructure as code using Terraform CLI tool within Ansible playbooks and Execution Environment runtimes |
 | [cloud.terraform_ops](https://github.com/redhat-cop/cloud.terraform_ops) | Validated content | Roles to help automate Terraform integration with Red Hat Ansible Automation Platform |
 | [community.aws](https://github.com/ansible-collections/community.aws) | Community | Automate AWS services |
 | [community.okd](https://github.com/ansible-collections/community.okd) | Community | Automate OKD (Openshift Upstream) |
-| [community.vmware](https://github.com/ansible-collections/community.vmware) | Community | Automate VMware |
 | [kubernetes.core](https://github.com/ansible-collections/kubernetes.core) | Supported | Automate Kubernetes |
 | redhat.openshift | Supported[^1] | Automate Openshift |
-| [vmware.vmware_rest](https://github.com/ansible-collections/vmware.vmware_rest) | Supported | Automate VMware |
 
 [^1]: While redhat.openshift is the supported collection for OpenShift, it is auto-generated from community.okd. As such, when changes are needed to the redhat.openshift collection they are first made in the community.okd repository and from that redhat.openshift is generated and uploaded to Ansible Automation Hub.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ownership of cloud.azure_ops, community.vmware and vmware.vmware_rest has shifted, and these collections are no longer maintained by the Cloud Content team.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
