### PR TITLE
Publish collection using Service account credentials

### DIFF
--- a/Releases/release_automation_hub.md
+++ b/Releases/release_automation_hub.md
@@ -34,6 +34,20 @@ auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-conn
 token=<automation_hub_token>
 ```
 
+> **Note**: This can eventually be done using Service account credentials (`sa_client_id` and `sa_client_secret` can be obtained from the Cloud team Bitwarden vault under the `ansible-automation-hub-sa` secret). This requires `ansible-core >= 2.19`. Using a Service account, the configuration will look like this: 
+
+```ini
+[galaxy]
+server_list = rh_automation_hub
+
+[galaxy_server.rh_automation_hub]
+
+url=https://cloud.redhat.com/api/automation-hub/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+client_id = <sa_client_id>
+client_secret = <sa_client_secret>
+```
+
 5. Publish the release
 
 ```shell


### PR DESCRIPTION
We can manually publish a collection to Automation Hub using Service account credentials instead of a Personal AH token.
The procedure is updated to describe how to do that.