### PR TITLE
Manual upload of Validated Content to AH is no more needed

### DIFF
--- a/Releases/release_collections.md
+++ b/Releases/release_collections.md
@@ -55,7 +55,7 @@ _Note : If the sanity tests fail locally or in the CI, the failures have to be a
 
 * Once the [CI for the release](https://ansible.softwarefactory-project.io/zuul/status) passes, post a message on the `#ansible-partners` Slack channel requesting an approval for any supported content collections (e.g., `amazon.aws`) for Automation Hub.
 
-* `redhat.openshift` collection is manually uploaded to Automation Hub. To manually upload a collection to Automation Hub, please refer to the instructions [here](https://github.com/ansible-collections/cloud-content-handbook/blob/main/Releases/release_automation_hub.md). Manual upload is performed in cases where automated upload to Automation Hub fails.
+* Manual upload is performed in cases where automated upload to Automation Hub fails. To do this, please refer to the instructions [here](https://github.com/ansible-collections/cloud-content-handbook/blob/main/Releases/release_automation_hub.md).
 
 * Check for the latest version of the collection on [Galaxy](https://galaxy.ansible.com) and, if applicable, Automation Hub.
 

--- a/Releases/release_collections.md
+++ b/Releases/release_collections.md
@@ -55,7 +55,7 @@ _Note : If the sanity tests fail locally or in the CI, the failures have to be a
 
 * Once the [CI for the release](https://ansible.softwarefactory-project.io/zuul/status) passes, post a message on the `#ansible-partners` Slack channel requesting an approval for any supported content collections (e.g., `amazon.aws`) for Automation Hub.
 
-* `Validated Content collections` and `redhat.openshift` collection are manually uploaded to Automation Hub. To manually upload a collection to Automation Hub, please refer to the instructions [here](https://github.com/ansible-collections/cloud-content-handbook/blob/main/Releases/release_automation_hub.md). Manual upload is performed in cases where automated upload to Automation Hub fails.
+* `redhat.openshift` collection is manually uploaded to Automation Hub. To manually upload a collection to Automation Hub, please refer to the instructions [here](https://github.com/ansible-collections/cloud-content-handbook/blob/main/Releases/release_automation_hub.md). Manual upload is performed in cases where automated upload to Automation Hub fails.
 
 * Check for the latest version of the collection on [Galaxy](https://galaxy.ansible.com) and, if applicable, Automation Hub.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Validated Content collections can be published to AH via Zuul (with PE approval). Manual uploads are not necessary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
